### PR TITLE
Clarify Python 3 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # tus.py
-tus (resumable file upload protocol) client in python
+tus (resumable file upload protocol) client compatible with python 3
+
+# Requirements
+
+You must be running Python3 to use tus
 
 # Install
 ```shell

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
tus.py uses `file.seekable` which it appears does not exist in Python 2.x:

```
$ python2.7
Python 2.7.16 (default, Jun 14 2019, 20:26:38)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> open("example.mp4").seekable()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'file' object has no attribute 'seekable'
```

It is present in 3.x

```
>>>
$ python3
Python 3.7.1 (default, Nov 28 2018, 11:55:14)
[Clang 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> open("example.mp4").seekable()
True
```